### PR TITLE
fix deprecation warning

### DIFF
--- a/assets/wiki/wiki.yaml
+++ b/assets/wiki/wiki.yaml
@@ -47,7 +47,7 @@ spec:
   selector:
     app: wiki
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wiki


### PR DESCRIPTION
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress